### PR TITLE
Staticfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ HGREV
 .pydevproject
 .tox/
 Django-*.egg
+.idea

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,6 +3,7 @@ Aram Dulyan
 Berker Peksag <berker.peksag@gmail.com>
 Carl Meyer <carl@oddbird.net>
 Fursov Sergey <GeyseR85@gmail.com>
+Ivan Ven Osdel <ivan@wimpyanalytics.com>
 James Turk <james.p.turk@gmail.com>
 Jannis Leidel <jannis@enn.io>
 Jeremy Carbaugh

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ CHANGES
 tip (unreleased)
 ----------------
 
+* Template tags now support Django's STATICFILES_STORAGE setting.
+  Thanks Ivan Ven Osdel for report and fix.
+
 2.2.2 (2014.09.08)
 ------------------
 

--- a/markitup/util.py
+++ b/markitup/util.py
@@ -1,15 +1,9 @@
 from __future__ import unicode_literals
 
-import posixpath
-
-from django.conf import settings as django_settings
-
-from markitup import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 
 
-def absolute_url(path, prefix=None):
-    if prefix is None:
-        prefix = django_settings.STATIC_URL
+def absolute_url(path):
     if path.startswith(u'http://') or path.startswith(u'https://') or path.startswith(u'/'):
         return path
-    return posixpath.join(prefix, path)
+    return staticfiles_storage.url(path)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,8 @@
+import posixpath
+
+from django.contrib.staticfiles.storage import FileSystemStorage
+
+
+class SomeCustomStorage(FileSystemStorage):
+    def url(self, name):
+        return posixpath.join('https://cdn.example.com/static', name)


### PR DESCRIPTION
This fix addresses an issue where the template tags assume local storage rather then going through staticfiles_storage.

#### Tested environments:
 * Success: py26-1.4, py26-1.6, py27-1.4, py27-1.6, py27-1.7, py33-1.6, py33-1.7, py34-1.6, py34-1.7
 * Untested: I was unable to test with these as they fail both before and after my changes. It doesn't seem to find the test_settings file for whatever reason: py26-1.5, py27-1.5, py33-1.5, py34-1.5